### PR TITLE
[WiiU] Aroma CFW Compatibility

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -314,7 +314,7 @@ else ifneq (,$(filter $(platform), ngc wii wiiu))
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
    PLATFORM_DEFINES += -DGEKKO -mcpu=750 -meabi -mhard-float
-   PLATFORM_DEFINES += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+   PLATFORM_DEFINES += -ffunction-sections -fdata-sections -D__wiiu__ -D__wut__
    STATIC_LINKING = 1
 
    # Nintendo WiiU


### PR DESCRIPTION
This update will make the Core compatible with the soon to be released Aroma Retroarch port.
This should also be Tiramisu safe too so should be good to merge :)