### PR TITLE
Fix compilation with PSL1GHT

### DIFF
--- a/libnumero/libretro/libretronew.cpp
+++ b/libnumero/libretro/libretronew.cpp
@@ -108,6 +108,13 @@ std::vector<NeilVirtualButton> virtualButtons;
 #include <stdarg.h>
 
 // LIBRETRO CALLBACKS
+#ifdef __PSL1GHT__
+// vsnprintf is compiled into newlib, 
+// but not exposed in the headers with PSL1GHT for some reason.
+#ifndef vsnprintf
+int vsnprintf (char *s, size_t n, const char *format, va_list ap);
+#endif
+#endif
 void PrintDebugOutput(const char* text, ...)
 {
     static char buf[1024];


### PR DESCRIPTION
vsnprintf is compiled into newlib, but not exposed in the headers with PSL1GHT for some reason. This pr adds the definition where it's used so numero can be built successfully