### PR TITLE
libretro: fix build on updated android ndk

### DIFF
--- a/libnumero/libretro/jni/Android.mk
+++ b/libnumero/libretro/jni/Android.mk
@@ -11,8 +11,17 @@ include $(ROOT_DIR)/Makefile.common
 COREFLAGS := -DINLINE=inline -DHAVE_STDINT_H -DHAVE_INTTYPES_H \
  -D__LIBRETRO__ -DVIDEO_RGB565 -Wno-c++11-narrowing
 
-CFLAGS :=  -funroll-loops -fsigned-char -ffast-math -fno-signed-zeros \
- -mfloat-abi=hard -mfpu=neon -mthumb -msoft-float
+CFLAGS := \
+    -funroll-loops \
+    -fsigned-char \
+    -ffast-math \
+    -fno-signed-zeros
+
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+CFLAGS += \
+    -mfpu=neon \
+    -mthumb
+endif
 
 ifeq ($(HAVE_NETWORK),1)
   COREFLAGS += -DHAVE_NETWORK


### PR DESCRIPTION
Android NDK r29.

Fixes: ```
make: *** [/opt/android-sdk-linux/ndk/29.0.14206865/build/core/build-binary.mk:422: /builds/libretro/numero/libnumero/libretro/obj/local/arm64-v8a/objs/retro//builds/libretro/numero/libnumero/libretro/jni/__/__/__/libnumero/src/core/control_reverse.o] Error 1
clang++: error: unsupported option '-mfloat-abi=' for target 'aarch64-none-linux-android21'
clang++: error: unsupported option '-mfpu=' for target 'aarch64-none-linux-android21'
clang++: error: unsupported option '-mfloat-abi=' for target 'aarch64-none-linux-android21'
clang++: error: unsupported option '-mfpu=' for target 'aarch64-none-linux-android21'
```

